### PR TITLE
:construction_worker: Only upload recipe

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,4 +55,4 @@ jobs:
       - name: 🆙 Upload package to `libhal-trunk` repo
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          conan upload "arm-gnu-toolchain/*" --confirm -r=libhal-trunk
+          conan upload "arm-gnu-toolchain/*" --only-recipe --confirm -r=libhal-trunk

--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -22,6 +22,7 @@ class ArmGnuToolchain(ConanFile):
     exports_sources = "toolchain.cmake"
     package_type = "application"
     short_paths = True
+    build_policy = "missing"
 
     @property
     def download_info(self):


### PR DESCRIPTION
Uploading more than the recipe will cost bandwidth and storage which has resulted in a large fee from JFrog.

Add policy to always build package if it is missing to ensure that it is downloaded from the source each time.