### PR TITLE
:fire: Remove compiler flags from toolchain recipe

### DIFF
--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -119,26 +119,3 @@ class ArmGnuToolchain(ConanFile):
 
         f = os.path.join(self.package_folder, "res/toolchain.cmake")
         self.conf_info.append("tools.cmake.cmaketoolchain:user_toolchain", f)
-
-        gcc_c_flags = [
-            "-mthumb",
-            "-ffunction-sections",
-            "-fdata-sections",
-        ]
-
-        gcc_cxx_flags = [
-            "-fno-exceptions",
-            "-fno-rtti"
-        ]
-
-        gcc_cxx_flags.extend(gcc_c_flags)
-
-        linker_flags = [
-            "-mthumb",
-            "-Wl,--gc-sections",
-            "-Wl,--print-memory-usage"
-        ]
-
-        self.conf_info.define("tools.build:cflags", gcc_c_flags)
-        self.conf_info.define("tools.build:cxxflags", gcc_cxx_flags)
-        self.conf_info.define("tools.build:exelinkflags", linker_flags)


### PR DESCRIPTION
The compiler recipe shouldn't dictate which compiler flags are automatically injected into a build. There are use cases and possibly experiments users may want to try that require some of these flags to be removed.