### PR TITLE
:package: Only upload packages from os ubuntu-22.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,6 @@ jobs:
         run: conan remote login -p $env:API_KEY libhal-trunk $env:JFROG_USER
 
       - name: 🆙 Upload package to `libhal-trunk` repo
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-22.04' }}
         run: |
           conan upload "arm-gnu-toolchain/*" --only-recipe --confirm -r=libhal-trunk


### PR DESCRIPTION
There is no need to upload packages from every OS, one should suffice. Windows also has uses /r/n line encoding, which causes conan to consider the Windows built package different than the *nix systems because the files are literally different.