### PR TITLE
:building_construction: Use options for newlib

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,8 +42,14 @@ jobs:
         run: conan create . --version=${{ inputs.version }}
 
       - name: 📦 Build Demos Conan Package
+        if: ${{ runner.os != 'Windows' }}
         working-directory: demo
-        run: conan build . -s compiler.version=${{ inputs.version }} -pr nano_nosys
+        run: VERBOSE=1 conan build . -pr profile -s compiler.version="${{ inputs.version }}"
+
+      - name: 📦 Build Demos Conan Package
+        if: ${{ runner.os == 'Windows' }}
+        working-directory: demo
+        run: conan build . -pr profile -s compiler.version="${{ inputs.version }}"
 
       - name: 📡 Sign into JFrog Artifactory
         if: ${{ github.ref == 'refs/heads/main' && runner.os != 'Windows' }}

--- a/demo/conanfile.py
+++ b/demo/conanfile.py
@@ -25,13 +25,6 @@ class Demo(ConanFile):
                 "This demo requires the compiler to be GCC, provided: " +
                 f"'{self.settings.compiler}'")
 
-        SUPPORTED_LIBC = ["nano", "nano_nosys"]
-        if str(self.settings.compiler.newlib) not in SUPPORTED_LIBC:
-            raise ConanInvalidConfiguration(
-                "newlib must be defined and one of these " +
-                f"{SUPPORTED_LIBC}, provided newlib: " +
-                f"'{self.settings.compiler.newlib}'")
-
     def build_requirements(self):
         self.tool_requires("cmake/3.27.1")
         self.tool_requires(f"arm-gnu-toolchain/{self._compiler_version}")
@@ -40,8 +33,7 @@ class Demo(ConanFile):
         pass
 
     def layout(self):
-        newlib = "build/" + str(self.settings.compiler.newlib)
-        cmake_layout(self, build_folder=newlib)
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)

--- a/demo/nano_nosys
+++ b/demo/nano_nosys
@@ -1,8 +1,0 @@
-[settings]
-build_type=MinSizeRel
-compiler=gcc
-compiler.cppstd=20
-compiler.libcxx=libstdc++
-compiler.newlib=nano_nosys
-arch=cortex-m4f
-os=baremetal

--- a/demo/profile
+++ b/demo/profile
@@ -2,7 +2,7 @@
 build_type=MinSizeRel
 compiler=gcc
 compiler.cppstd=20
+compiler.version=12.2
 compiler.libcxx=libstdc++
-compiler.newlib=nano
 arch=cortex-m4f
 os=baremetal


### PR DESCRIPTION
Using newlib as a compatibility setting is incorrect as the choice of newlib libc library implementation is a link time choice and does not affect codegen or ABI.